### PR TITLE
First (basic) implementation of variable fonts with font-weights

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -2,6 +2,7 @@
 @import 'utils/functions';
 @import 'utils/google';
 @import 'load/load';
+@import 'load/variable-load';
 @import 'load/usage';
 @import 'style/index';
 
@@ -10,3 +11,5 @@
 @include font-load($font-secondary);
 @include font-load($font-tertiary);
 @include font-load($font-quaternary);
+
+@include font-variable-load($font-variable);

--- a/src/load/_variable-load.scss
+++ b/src/load/_variable-load.scss
@@ -14,7 +14,6 @@
 
 // Check the font and load them.
 @mixin font-variable-load($font) {
-	@debug $font;
 	//
 	// Define scoped variables
 	$load: false;

--- a/src/load/_variable-load.scss
+++ b/src/load/_variable-load.scss
@@ -1,0 +1,71 @@
+
+@mixin font-variable-include(
+	$name,
+	$file,
+	$weight-range: 200 700,
+	$path: $base-font-path
+) {
+	@font-face {
+		src: url('#{$path}/#{$file}.woff2') format("woff-variations");
+		font-weight: $weight-range;
+		font-family: $name;
+	}
+}
+
+// Check the font and load them.
+@mixin font-variable-load($font) {
+	@debug $font;
+	//
+	// Define scoped variables
+	$load: false;
+	$font-name: '';
+	$font-path: $base-font-path !default;
+	$family: '';
+
+	//
+	// Check if the variable is a map
+	// if it's not a map, its not a font to include.
+	@if type-of($font) == 'map' {
+		//
+		// Check if the include has a font-family;
+		@if map-has-key($font, 'font-family') == false {
+			@warn "Your included font doesn't have a specified 'font-family'";
+		} @else {
+			//
+			// Check if the font if it needs to load, has weights to include.
+			@if map-has-key($font, 'load') {
+				@if map-get($font, 'load') == true {
+					@if map-has-key($font, 'weight-range') == false {
+						@warn "You are trying to include a font without weight range, please specify the weight-range to load.";
+					} @else {
+						$load: true;
+					}
+				}
+			}
+			// Check if a font path has been set, if so, override the default;
+			@if map-has-key($font, 'path') {
+				$font-path: map-get($font, 'path');
+			}
+			
+			// Check if a font files have been set
+			@if map-has-key($font, 'files') {
+				$font-files: map-get($font, 'files');
+			}
+
+			// Load the fonts if true
+			@if $load {
+				@include font-variable-include(
+					convertToFontname($font),
+					convertToFontname($font, true),
+					map-get($font, weight-range),
+					$font-path
+				);
+			}
+
+			// Set use
+			@if map-has-key($font, 'use') {
+				@include font-use(map-get($font, 'use'), map-get($font, 'font-family'));
+			}
+		}
+	}
+}

--- a/src/style/_variables.scss
+++ b/src/style/_variables.scss
@@ -7,3 +7,5 @@ $font-primary: $system-fonts !default;
 $font-secondary: null !default;
 $font-tertiary: null !default;
 $font-quaternary: null !default;
+
+$font-variable: null !default;


### PR DESCRIPTION
Added a first basic implementation of Variable fonts, respected the current implementation of fonts as much as possible by adding an additional "font-family-variable" called `$font-variable`.

Can be tested with this SF pro variable font: https://www.dropbox.com/s/in7kytk9q1qz6im/SF-Pro-Display-Variable.woff2?dl=0

And this added to `_embed.scss`:

```
$font-variable: (
  font-family: (
		"SF-Pro-Display-Variable",
		serif
	),
  load: true,
  weight-range: 1 1000,
  path: '~assets/fonts',
	use: (
		p,
		body,
		li,
		h1,
		h2,
		h3,
		h4,
		h5,
		h6,
		strong
	)
);
```
